### PR TITLE
Auto Tom Optimisation correctly sets multiple toms

### DIFF
--- a/src/com/fureniku/miditochdrums/ConverterScreen.java
+++ b/src/com/fureniku/miditochdrums/ConverterScreen.java
@@ -222,25 +222,19 @@ public class ConverterScreen extends JFrame {
         if (finalUseToms.size() == 4) {
             panelNotes.setYellow(finalUseToms.get(3) + "");
             panelNotes.setBlue(finalUseToms.get(2) + "");
-            panelNotes.setGreen(finalUseToms.get(1) + "");
-            panelNotes.setGreen(finalUseToms.get(0) + "");
+            panelNotes.setGreen(finalUseToms.get(1) + "," + finalUseToms.get(0));
         }
 
         if (finalUseToms.size() == 5) {
             panelNotes.setYellow(finalUseToms.get(4) + "");
-            panelNotes.setBlue(finalUseToms.get(3) + "");
-            panelNotes.setBlue(finalUseToms.get(2) + "");
-            panelNotes.setGreen(finalUseToms.get(1) + "");
-            panelNotes.setGreen(finalUseToms.get(0) + "");
+            panelNotes.setBlue(finalUseToms.get(3) + "," + finalUseToms.get(2));
+            panelNotes.setGreen(finalUseToms.get(1) + "," + finalUseToms.get(0));
         }
 
         if (finalUseToms.size() == 6) {
-            panelNotes.setYellow(finalUseToms.get(5) + "");
-            panelNotes.setYellow(finalUseToms.get(4) + "");
-            panelNotes.setBlue(finalUseToms.get(3) + "");
-            panelNotes.setBlue(finalUseToms.get(2) + "");
-            panelNotes.setGreen(finalUseToms.get(1) + "");
-            panelNotes.setGreen(finalUseToms.get(0) + "");
+            panelNotes.setYellow(finalUseToms.get(5) + ","+ finalUseToms.get(4));
+            panelNotes.setBlue(finalUseToms.get(3) + "," + finalUseToms.get(2));
+            panelNotes.setGreen(finalUseToms.get(1) + "," + finalUseToms.get(0));
         }
     }
 


### PR DESCRIPTION
When clicking convert on a song while using Auto Tom Optimisation it would replace the text in the field with only one number, then error that it didn't know other numbers in the song. Existing code was overriding the values for each tom when multiple needed to be set, instead of joining them with a comma.